### PR TITLE
Add potato chat component

### DIFF
--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  export let role: 'user' | 'assistant';
+  export let text: string;
+</script>
+
+<div class={`message ${role}`}>{text}</div>
+
+<style>
+  .message {
+    padding: 0.25rem 0.5rem;
+    margin: 0.25rem 0;
+    border-radius: 0.375rem;
+  }
+  .user {
+    background-color: #e5f2ff;
+    align-self: flex-end;
+  }
+  .assistant {
+    background-color: #f4f4f4;
+    align-self: flex-start;
+  }
+</style>

--- a/src/lib/components/ChatWindow.svelte
+++ b/src/lib/components/ChatWindow.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import ChatMessage from './ChatMessage.svelte';
+
+  interface Message {
+    role: 'user' | 'assistant';
+    text: string;
+  }
+
+  let messages: Message[] = [];
+  let input = '';
+
+  function send() {
+    const text = input.trim();
+    if (!text) return;
+    messages = [...messages, { role: 'user', text }];
+    input = '';
+    // respond with potato emoji
+    messages = [...messages, { role: 'assistant', text: '🥔' }];
+  }
+
+  function handleKey(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      send();
+    }
+  }
+</script>
+
+<div class="chat-window">
+  <div class="messages">
+    {#each messages as m (m)}
+      <ChatMessage {role}={m.role} {text}={m.text} />
+    {/each}
+  </div>
+  <div class="input-row">
+    <textarea bind:value={input} on:keydown={handleKey} rows="2" placeholder="Ask me anything..."></textarea>
+    <button on:click={send}>Ask</button>
+  </div>
+</div>
+
+<style>
+  .chat-window {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+    max-width: 30rem;
+  }
+  .messages {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    border: 1px solid #ddd;
+    padding: 0.5rem;
+    min-height: 10rem;
+    max-height: 20rem;
+    overflow-y: auto;
+  }
+  .input-row {
+    display: flex;
+    gap: 0.5rem;
+  }
+  textarea {
+    flex: 1;
+    padding: 0.25rem;
+  }
+  button {
+    padding: 0.25rem 0.75rem;
+  }
+</style>

--- a/src/lib/components/Potato.svelte
+++ b/src/lib/components/Potato.svelte
@@ -1,4 +1,11 @@
-<div class="potato"><h1>🥔</h1></div>
+<script lang="ts">
+  import ChatWindow from './ChatWindow.svelte';
+</script>
+
+<div class="potato">
+  <h1>🥔</h1>
+  <ChatWindow />
+</div>
 
 <style>
 	div {


### PR DESCRIPTION
## Summary
- create `ChatWindow` and `ChatMessage` components
- extend `Potato` to include the chat window

## Testing
- `npm test` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_684eb8383d78832d82923ce323aba51e